### PR TITLE
BUG: Phonelog fixes

### DIFF
--- a/angular-client/src/app/components/phonelog/add-phonelog/add-phonelog.component.html
+++ b/angular-client/src/app/components/phonelog/add-phonelog/add-phonelog.component.html
@@ -18,6 +18,14 @@
   </div>
 
   <mat-form-field>
+    <mat-select placeholder="Language" name="language" formControlName="language">
+      <mat-option *ngFor="let lang of language" [value]="lang">
+        {{lang}}
+      </mat-option>
+    </mat-select>
+  </mat-form-field>
+
+  <mat-form-field>
     <mat-select placeholder="Type of caller" name="callertype" formControlName="callertype">
       <mat-option *ngFor="let caller of callertype" [value]="caller">
         {{caller}}
@@ -25,12 +33,7 @@
     </mat-select>
   </mat-form-field>
 
-  <mat-form-field class="phonenumber">
-    <input matInput placeholder="Phone number" name="phonenumber" formControlName="phonenumber">
-  </mat-form-field>
-
   <div class="message-header">
-    
     <mat-form-field>
       <mat-select placeholder="Reason for call" name="subject" formControlName="subject">
         <mat-option *ngFor="let subject of subjects" [value]="subject">
@@ -43,6 +46,10 @@
       Urgent
     </mat-slide-toggle>
   </div>
+
+  <mat-form-field class="phonenumber">
+    <input matInput placeholder="Phone number" name="phonenumber" formControlName="phonenumber">
+  </mat-form-field>
 
   <mat-form-field class="message">
     <textarea matInput placeholder="Message" matTextareaAutosize matAutosizeMinRows="5" name="message" formControlName="message"></textarea>

--- a/angular-client/src/app/components/phonelog/add-phonelog/add-phonelog.component.ts
+++ b/angular-client/src/app/components/phonelog/add-phonelog/add-phonelog.component.ts
@@ -29,7 +29,6 @@ export class AddPhonelogComponent implements OnInit {
     'Français',
     'English',
     'Español',
-    'Other',
   ];
   pronouns = [
     'undisclosed',

--- a/angular-client/src/app/components/phonelog/add-phonelog/add-phonelog.component.ts
+++ b/angular-client/src/app/components/phonelog/add-phonelog/add-phonelog.component.ts
@@ -25,6 +25,12 @@ export class AddPhonelogComponent implements OnInit {
     'Social worker',
     'Other person',
   ];
+  language = [
+    'Français',
+    'English',
+    'Español',
+    'Other',
+  ];
   pronouns = [
     'undisclosed',
     'she/her',
@@ -72,6 +78,7 @@ export class AddPhonelogComponent implements OnInit {
       name: ['', Validators.required],
       pronouns: this.pronouns[0],
       user: '',
+      language: this.language[0],
       urgent: false,
       phonenumber: ['', Validators.pattern(this.phoneregex)],
       subject: this.subjects[0],

--- a/angular-client/src/app/components/phonelog/edit-phonelog/edit-phonelog.component.html
+++ b/angular-client/src/app/components/phonelog/edit-phonelog/edit-phonelog.component.html
@@ -22,8 +22,12 @@
         </mat-select>
     </mat-form-field>
 
-    <mat-form-field class="language">
-        <input matInput placeholder="Language" name="language" formControlName="language">
+    <mat-form-field>
+        <mat-select placeholder="Language" name="language" formControlName="language">
+            <mat-option *ngFor="let lang of language" [value]="lang">
+                {{lang}}
+            </mat-option>
+        </mat-select>
     </mat-form-field>
 
     <mat-form-field class="call-phone">

--- a/angular-client/src/app/components/phonelog/edit-phonelog/edit-phonelog.component.ts
+++ b/angular-client/src/app/components/phonelog/edit-phonelog/edit-phonelog.component.ts
@@ -21,6 +21,12 @@ export class EditPhonelogComponent implements OnInit {
     'Social worker',
     'Other person',
   ];
+  language = [
+    'Français',
+    'English',
+    'Español',
+    'Other',
+  ];
   pronouns = [
     'undisclosed',
     'she/her',
@@ -54,7 +60,7 @@ export class EditPhonelogComponent implements OnInit {
     this.editphonelog = this.form.group({
       name: [this.log.name, Validators.required],
       pronouns: this.log.pronouns || this.pronouns[0],
-      language: this.log.language || '',
+      language: this.log.language || this.language[0],
       urgent: this.log.urgent,
       phonenumber: [this.log.phonenumber || '', Validators.pattern(this.phoneregex)],
       subject: this.log.subject || this.subjects[0],

--- a/angular-client/src/app/components/phonelog/edit-phonelog/edit-phonelog.component.ts
+++ b/angular-client/src/app/components/phonelog/edit-phonelog/edit-phonelog.component.ts
@@ -25,7 +25,6 @@ export class EditPhonelogComponent implements OnInit {
     'Français',
     'English',
     'Español',
-    'Other',
   ];
   pronouns = [
     'undisclosed',

--- a/angular-client/src/app/components/phonelog/view-phonelog/view-phonelog.component.html
+++ b/angular-client/src/app/components/phonelog/view-phonelog/view-phonelog.component.html
@@ -42,7 +42,7 @@
                     <div class="call-text">{{log.message}}</div>
                 </div>
                 <div class="logger">
-                    <div class="label">Call logged by:</div> {{log.user ? log.user.name : "DELETED USER"}}
+                    <div class="label">Call logged by:</div> {{log.user ? log.user.name : "A user that has since been deleted."}}
                 </div>
 
             </mat-card-content>
@@ -129,11 +129,11 @@
                         <br>
                     </div>
                     <div>
-                        <b> Call logged by: </b> {{log.user ? log.user.name : "DELETED USER"}}
+                        <b> Call logged by: </b> {{log.user ? log.user.name : "A user that has since been deleted."}}
                         <br>
                     </div>
                     <div>
-                        <b> Called back by: </b> {{log.resolvedBy ? log.resolvedBy.name : "DELETED USER"}}
+                        <b> Called back by: </b> {{log.resolvedBy ? log.resolvedBy.name : "A user that has since been deleted."}}
                         <br>
                     </div>
                     <div>

--- a/angular-client/src/app/components/phonelog/view-phonelog/view-phonelog.component.html
+++ b/angular-client/src/app/components/phonelog/view-phonelog/view-phonelog.component.html
@@ -42,7 +42,7 @@
                     <div class="call-text">{{log.message}}</div>
                 </div>
                 <div class="logger">
-                    <div class="label">Call logged by:</div> {{log.user.name}}
+                    <div class="label">Call logged by:</div> {{log.user ? log.user.name : "DELETED USER"}}
                 </div>
 
             </mat-card-content>
@@ -129,11 +129,11 @@
                         <br>
                     </div>
                     <div>
-                        <b> Call logged by: </b> {{log.user.name}}
+                        <b> Call logged by: </b> {{log.user ? log.user.name : "DELETED USER"}}
                         <br>
                     </div>
                     <div>
-                        <b> Called back by: </b> {{log.resolvedBy.name}}
+                        <b> Called back by: </b> {{log.resolvedBy ? log.resolvedBy.name : "DELETED USER"}}
                         <br>
                     </div>
                     <div>

--- a/angular-client/src/app/components/reports/reports.component.spec.ts
+++ b/angular-client/src/app/components/reports/reports.component.spec.ts
@@ -5,6 +5,12 @@ import { MaterialsModule } from '../../modules/materials.module';
 import { ReportPhonelogService } from '../../services/reports-phonelog.service';
 import { HttpClientModule } from '@angular/common/http';
 import { MessageService } from '../../services/message.service';
+import { PhonelogService } from '../../services/phonelog.service';
+import { MockPhonelogService } from '../../services/mocks/MockPhonelogService';
+import { AuthenticationService } from '../../services/authentication.service';
+import { MockAuthenticationService } from '../../services/mocks/MockAuthenticationService';
+import { EventEmitter } from '@angular/core';
+import { Router } from '@angular/router';
 
 
 describe('ReportsComponent', () => {
@@ -16,7 +22,11 @@ describe('ReportsComponent', () => {
       declarations: [ ReportsComponent ],
       schemas: [ NO_ERRORS_SCHEMA ],
       imports: [ MaterialsModule, HttpClientModule ],
-      providers: [ReportPhonelogService, MessageService]
+      providers: [ReportPhonelogService, MessageService,
+        { provide: AuthenticationService, useClass: MockAuthenticationService },
+        { provide: PhonelogService, useClass: MockPhonelogService },
+        { provide: Router, useValue: { navigateByUrl: jasmine.createSpy('navigateByUrl')}},
+      ]
     })
     .compileComponents();
   }));

--- a/angular-client/src/app/components/reports/reports.component.ts
+++ b/angular-client/src/app/components/reports/reports.component.ts
@@ -1,12 +1,18 @@
-import { Component, OnInit, AfterContentInit } from '@angular/core';
+import { Component, OnInit, Input, AfterContentInit, OnChanges } from '@angular/core';
 import { ReportPhonelogService } from '../../services/reports-phonelog.service';
+import { PhonelogService } from '../../services/phonelog.service';
+import { AuthenticationService } from '../../services/authentication.service';
+import { RouterModule, Router } from '@angular/router';
 
 @Component({
   selector: 'app-reports',
   templateUrl: './reports.component.html',
   styleUrls: ['./reports.component.css']
 })
-export class ReportsComponent implements OnInit {
+export class ReportsComponent implements OnInit, OnChanges {
+  
+  @Input() reloadPhonelogs: boolean;
+
   public isPhonelogUrgenciesDataReady = false;
   public phonelogUrgencies;
   public isCallerTypeDataReady = false;
@@ -34,10 +40,33 @@ export class ReportsComponent implements OnInit {
     'Sexual Health',
     'Information '
   ];
-  constructor(private reportPhonelogService: ReportPhonelogService) { }
+  constructor(
+    private reportPhonelogService: ReportPhonelogService,
+    private phonelogService: PhonelogService,
+    public authService: AuthenticationService,
+    public router: Router
+  ) {
+    this.phonelogService.phoneLogged.subscribe(_ => {
+      this.fetchAllStatistics();
+    });
+   }
 
 
   ngOnInit() {
+    if (!this.authService.loggedIn) {
+      this.router.navigateByUrl('login');
+    } else {
+      this.fetchAllStatistics();
+    }
+  }
+
+  ngOnChanges() {
+    if (this.reloadPhonelogs) {
+      this.fetchAllStatistics();
+    }
+  }
+
+  fetchAllStatistics() {
     this.fetchCallerUrgencyStatistics();
     this.fetchCallerTypeStatistics();
     this.fetchCallerPronounsStatistics();

--- a/angular-client/src/app/components/reports/reports.component.ts
+++ b/angular-client/src/app/components/reports/reports.component.ts
@@ -62,8 +62,16 @@ export class ReportsComponent implements OnInit, OnChanges {
 
   ngOnChanges() {
     if (this.reloadPhonelogs) {
+      this.unsetAllReady();
       this.fetchAllStatistics();
     }
+  }
+
+  unsetAllReady() {
+    this.isPhonelogUrgenciesDataReady = false;
+    this.isCallerPronounsDataReady = false;
+    this.isCallerTypeDataReady = false;
+    this.isCallerTypeDataReady = false;
   }
 
   fetchAllStatistics() {

--- a/angular-client/src/app/services/phonelog.service.ts
+++ b/angular-client/src/app/services/phonelog.service.ts
@@ -25,7 +25,7 @@ export class PhonelogService {
   getAll(): Observable<Object> {
     return this.http.get(this.url)
       .pipe(
-      tap(cases => this.log('fecthed all cases')),
+      tap(cases => this.log('fetched all cases')),
       catchError(this.handleError<Object>('getAll()'))
       );
   }
@@ -33,7 +33,7 @@ export class PhonelogService {
   getActive(): Observable<Object> {
     return this.http.get(`${this.url}/active`)
       .pipe(
-        tap(participants => this.log('fecthed logs')),
+        tap(participants => this.log('fetched logs')),
         catchError(this.handleError<Object>('getActive()'))
       );
   }
@@ -41,7 +41,7 @@ export class PhonelogService {
   getByResolved(): Observable<Object> {
     return this.http.get(`${this.url}/resolved`)
       .pipe(
-        tap(participants => this.log('fecthed logs')),
+        tap(participants => this.log('fetched logs')),
         catchError(this.handleError<Object>('getActive()'))
       );
   }
@@ -49,7 +49,7 @@ export class PhonelogService {
   getRecentlyUpdated(): Observable<Object> {
     return this.http.get(`${this.url}/recent`)
     .pipe(
-      tap(participants => this.log('fecthed recently updated logs')),
+      tap(participants => this.log('fetched recently updated logs')),
       catchError(this.handleError<Object>('getRecentlyUpdated()'))
     );
   }
@@ -57,7 +57,7 @@ export class PhonelogService {
   getByDeleted(): Observable<Object> {
     return this.http.get(`${this.url}/deleted`)
       .pipe(
-        tap(participants => this.log('fecthed logs')),
+        tap(participants => this.log('fetched logs')),
         catchError(this.handleError<Object>('getByDeleted()'))
       );
   }
@@ -137,7 +137,7 @@ export class PhonelogService {
       );
   }
 
-  emitPhoneLogging(): void {
+  public emitPhoneLogging(): void {
     this.phoneLogged.emit();
   }
 

--- a/express-server/routes/phonelog.route.js
+++ b/express-server/routes/phonelog.route.js
@@ -85,6 +85,7 @@ router.post('/', (req, res) => {
         name: req.body.name,
         pronouns: req.body.pronouns,
         user: req.user._id,
+        language: req.body.language,
         urgent: req.body.urgent,
         phonenumber: req.body.phonenumber,
         subject: req.body.subject,


### PR DESCRIPTION
At ASTT(e)Q they pointed out that we had not put the language upon entering a phonecall.
This PR fixes that.

Also, calls logged by Users who were subsequently deleted are no longer putting the frontend in an error state, when the `log.user == null`, the legend `DELETED USER`now  is being displayed.

Also, I borrowed some @Ldhatter code to make the reports modules listen on changes to new phone logs... So reports are generated automatically upon changes!
 